### PR TITLE
Fixes RT#90695 Moose enum warnings

### DIFF
--- a/lib/Bot/Backbone/Types.pm
+++ b/lib/Bot/Backbone/Types.pm
@@ -33,7 +33,7 @@ This is an enum with the following values:
 =cut
 
 class_type 'Moose::Meta::Class';
-enum DispatcherType, qw( bot service );
+enum DispatcherType, [qw( bot service )];
 coerce DispatcherType,
     from 'Moose::Meta::Class',
     via { 


### PR DESCRIPTION
Fixes https://rt.cpan.org/Ticket/Display.html?id=90695

The new Moose update change the way enum should be called and calling it the old way generates warnings.
