### PR TITLE
Fixes RT#90955 Class::MOP::load_class deprecation warnings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,7 @@ skip = ^Bot::Backbone::Dispatcher::Predicate
 
 [Prereqs]
 POE::Loop::EV = 0
+Class::Load = 0.20
 
 [AutoVersion]
 major = 0

--- a/lib/Bot/Backbone.pm
+++ b/lib/Bot/Backbone.pm
@@ -3,6 +3,7 @@ use v5.10;
 use Moose();
 use Bot::Backbone::DispatchSugar();
 use Moose::Exporter;
+use Class::Load;
 
 use Bot::Backbone::Meta::Class::Bot;
 use Bot::Backbone::Dispatcher;
@@ -224,7 +225,7 @@ sub _resolve_class_name {
         $class_name = join '::', 'Bot::Backbone', $section, $class_name;
     }
 
-    Class::MOP::load_class($class_name);
+    Class::Load::load_class($class_name);
     return $class_name;
 }
 

--- a/lib/Bot/Backbone/Service.pm
+++ b/lib/Bot/Backbone/Service.pm
@@ -4,6 +4,7 @@ use Moose();
 use Bot::Backbone::DispatchSugar();
 use Moose::Exporter;
 use Moose::Util qw( ensure_all_roles );
+use Class::Load;
 
 use Bot::Backbone::Meta::Class::Service;
 use Bot::Backbone::Dispatcher;
@@ -78,7 +79,7 @@ Similar to C<with> provided by L<Moose>, this defines a list of roles that shoul
 
 sub with_bot_roles {
     my ($meta, @roles) = @_;
-    Class::MOP::load_class($_) for @roles;
+    Class::Load::load_class($_) for @roles;
     $meta->add_bot_roles(@roles);
 }
 


### PR DESCRIPTION
This fixes RT#90955: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90955
